### PR TITLE
Provide way to change interval between evaluating conditions driver.wait (logs overflowing)

### DIFF
--- a/javascript/node/selenium-webdriver/lib/webdriver.js
+++ b/javascript/node/selenium-webdriver/lib/webdriver.js
@@ -764,7 +764,7 @@ class WebDriver {
   }
 
   /** @override */
-  wait(condition, timeout = 0, message = undefined) {
+  wait(condition, timeout = 0, message = undefined, interval = undefined) {
     if (typeof timeout !== 'number' || timeout < 0) {
       throw TypeError('timeout must be a number >= 0: ' + timeout);
     }
@@ -835,7 +835,7 @@ class WebDriver {
                   (message ? `${message}\n` : '')
                         + `Wait timed out after ${elapsed}ms`));
           } else {
-            setTimeout(pollCondition, 0);
+            setTimeout(pollCondition, interval || 0);
           }
         }, reject);
       };


### PR DESCRIPTION
I don't know the reason why it is implemented this way but it doesn't seem reasonable that conditions are checked in driver.wait immediately one after another until it success or timeout. This implementation cause overflowing logs like this:
(example where condition is fulfilled after 2 sec, it produces 200 lines of logs - i didn't count but a lot)
https://www.youtube.com/watch?v=S-xYB7YIDgE
Implementing extra parameter (easiest and backward compatible) like I suggest would change when using 300 ms timeout this situation to this:

If this pull request wan't be accepted (I wan't be surprised) at least explain me how to live with this:
https://youtu.be/xURuynUmnHo

Cheers
Btw doc for this repo is brilliant (I know that it is generated but anyway ;) )

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
